### PR TITLE
Authentication - Add user setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Here are instructions on how to contribute:
 * Try to keep it KISS: If it can be done simply, keep it simple. Also, do not add unnecessary dependencies.
 * The project doesn't have coding style guidelines nor a linter, but keep the code readable and do not add unnecessary files to your commits.
 * Please use reviewable.io to respond to PR's reviews.
+* When using translation strings on code, please run `lupdate -verbose -pro chaotic-installer.pro` to generate the translations source on `lang` folder.
 
 Others suggestions:
 * To understand the code, start with `src/main.cpp` and `qml/MainContainer.qml`.

--- a/chaotic-installer.pro
+++ b/chaotic-installer.pro
@@ -11,11 +11,13 @@ TRANSLATIONS = langs/en_US.ts langs/pt_BR.ts
 HEADERS = chaotic-installer.hpp \
 	lib/translations.hpp lib/keymap.hpp \
 	lib/network.hpp lib/mirrors.hpp \
-	lib/locales.hpp
+	lib/locales.hpp \
+        lib/user.hpp
 SOURCES = main.cpp \
 	lib/translations.cpp  lib/keymap.cpp \
 	lib/network.cpp lib/mirrors.cpp \
-	lib/locales.cpp
+	lib/locales.cpp \
+        lib/user.cpp
 TARGET = bin/chaotic-installer
 
 lupdate_only {

--- a/langs/en_US.ts
+++ b/langs/en_US.ts
@@ -139,6 +139,41 @@ this profile can be manually edited before starting it.</source>
     </message>
 </context>
 <context>
+    <name>UserSetup</name>
+    <message>
+        <source>User settings</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Confirm Password</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Root settings</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Hostname:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation></translation>
+    </message>
+</context>
+<context>
     <name>WifiMenu</name>
     <message>
         <source>Select adapter: </source>

--- a/langs/pt_BR.ts
+++ b/langs/pt_BR.ts
@@ -222,6 +222,41 @@ um script para o netctl, esse script poderá ser editado antes de conectar.</tra
     </message>
 </context>
 <context>
+    <name>UserSetup</name>
+    <message>
+        <source>User settings</source>
+        <translation>Configurações de usuário</translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation>Senha</translation>
+    </message>
+    <message>
+        <source>Confirm Password</source>
+        <translation>Confirmar senha</translation>
+    </message>
+    <message>
+        <source>Root settings</source>
+        <translation>Configurações de root</translation>
+    </message>
+    <message>
+        <source>Hostname:</source>
+        <translation>Nome do host</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <source>Apply</source>
+        <translation>Aplicar</translation>
+    </message>
+</context>
+<context>
     <name>WifiMenu</name>
     <message>
         <source>Select adapter: </source>

--- a/qml/LocalesSelect.qml
+++ b/qml/LocalesSelect.qml
@@ -104,7 +104,7 @@ Component {
             Button {
                 text: qsTr('Next')
                 highlighted: true
-                onClicked: contentStack.push(nextMenu)
+                onClicked: contentStack.push(userSetup)
             }
         }
     }

--- a/qml/MainContainer.qml
+++ b/qml/MainContainer.qml
@@ -82,4 +82,5 @@ Rectangle {
     EthernetMenu { id: ethMenu }
     MirrorsSort { id: mirrorsSort }
     LocalesSelect { id: localesSelect }
+    UserSetup { id: userSetup }
 }

--- a/qml/UserSetup.qml
+++ b/qml/UserSetup.qml
@@ -1,0 +1,216 @@
+import QtQuick 2.0
+
+import QtQuick 2.2
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
+import QtQuick.Layouts 1.3
+
+Component {
+    ColumnLayout {
+        spacing: 0
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            Layout.fillWidth: true
+
+            Column {
+                RowLayout {
+                    spacing: 50
+
+                    Column {
+                        spacing: 15
+
+                        Row {
+                            GroupBox {
+                                title: qsTr("User settings")
+
+                                Column {
+                                    spacing: 10
+
+                                    Row {
+                                        Column {
+                                            Row {
+                                                Text {
+                                                    text: qsTr("Name")
+                                                }
+                                            }
+
+                                            Row {
+                                                TextField {
+                                                    onEditingFinished: {
+                                                        user.setUserName(text);
+                                                        user.validateFields();
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    Row {
+                                        Column {
+                                            Row {
+                                                Text {
+                                                    text: qsTr("Password")
+                                                }
+                                            }
+
+                                            Row {
+                                                TextField {
+                                                    echoMode: TextInput.PasswordEchoOnEdit
+                                                    onEditingFinished: {
+                                                        user.setUserPassword(text);
+                                                        user.validateFields();
+                                                    }
+                                                    passwordCharacter: "*"
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    Row {
+                                        Column {
+                                            Row {
+                                                Text {
+                                                    text: qsTr("Confirm Password")
+                                                }
+                                            }
+
+                                            Row {
+                                                TextField {
+                                                    echoMode: TextInput.Password
+                                                    onEditingFinished: {
+                                                        user.setUserPasswordConfirm(text);
+                                                        user.validateFields();
+                                                    }
+                                                    passwordCharacter: "*"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Column {
+                        Layout.fillHeight: true
+                        spacing: 15
+
+                        Row {
+                            GroupBox {
+                                title: qsTr("Root settings")
+
+                                Column {
+                                    spacing: 10
+
+                                    Row {
+                                        Column {
+                                            Row {
+                                                Text {
+                                                    text: qsTr("Password")
+                                                }
+                                            }
+
+                                            Row {
+                                                TextField {
+                                                    echoMode: TextInput.Password
+                                                    onEditingFinished: {
+                                                        user.setRootPassword(text);
+                                                        user.validateFields();
+                                                    }
+                                                    passwordCharacter: "*"
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    Row {
+                                        Column {
+                                            Row {
+                                                Text {
+                                                    text: qsTr("Confirm Password")
+                                                }
+                                            }
+
+                                            Row {
+                                                TextField {
+                                                    echoMode: TextInput.Password
+                                                    onEditingFinished: {
+                                                        user.setRootPasswordConfirm(text);
+                                                        user.validateFields();
+                                                    }
+                                                    passwordCharacter: "*"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Layout.fillWidth: true
+                    }
+                }
+            }
+
+        }
+
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+            spacing: 20
+
+            Column {
+                Text {
+                    text: qsTr("Hostname:")
+                }
+            }
+
+            Column {
+                TextField {
+                    onEditingFinished: {
+                        user.setHostName(text);
+                        user.validateFields();
+                    }
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            Layout.topMargin: 20
+
+            Column {
+                Layout.minimumHeight: 20
+                Layout.minimumWidth: 100
+
+                Text {
+                    color: "#cf0606"
+                    text: user.error
+                }
+            }
+        }
+
+        RowLayout {
+            spacing: 80
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            Layout.topMargin: 20
+            Layout.bottomMargin: 20
+
+            Column {
+                Button {
+                    text: qsTr("Cancel")
+                }
+            }
+
+            Column {
+                Button {
+                    text: qsTr("Apply")
+                    enabled: user.isValid
+                    highlighted: user.isValid
+                    onClicked: contentStack.push(nextStep)
+                }
+            }
+        }
+
+
+
+    }
+}

--- a/src/lib/user.cpp
+++ b/src/lib/user.cpp
@@ -1,0 +1,111 @@
+#include <QDebug>
+
+#include "user.hpp"
+
+User::User(QObject *parent) : QObject(parent)
+{
+
+}
+
+void User::setHostName(QString hostname) {
+    hostName = hostname;
+}
+
+void User::setUserName(QString username) {
+    userName = username;
+}
+
+void User::setUserPassword(QString password) {
+    userPassword = password;
+}
+
+void User::setUserPasswordConfirm(QString passwordConfirm) {
+    userPasswordConfirm = passwordConfirm;
+}
+
+void User::setRootPassword(QString password) {
+    rootPassword = password;
+}
+
+void User::setRootPasswordConfirm(QString passwordConfirm) {
+    rootPasswordConfirm = passwordConfirm;
+}
+
+void User::setError(QString errorMessage) {
+    error = errorMessage;
+    emit errorChanged();
+}
+
+void User::setIsValid(bool valid) {
+    isValid = valid;
+    emit validationChanged();
+}
+
+QString User::getHostName() {
+    return hostName;
+}
+
+QString User::getUserName() {
+    return userName;
+}
+
+QString User::getUserPassword() {
+    return userPassword;
+}
+
+QString User::getUserPasswordConfirm() {
+    return userPasswordConfirm;
+}
+
+QString User::getRootPassword() {
+    return rootPassword;
+}
+
+QString User::getRootPasswordConfirm() {
+    return rootPasswordConfirm;
+}
+
+QString User::getError() {
+    return error;
+}
+
+bool User::getIsValid() {
+    return isValid;
+}
+
+bool isEmpty(QString text) {
+    return text.trimmed().size() == 0;
+}
+
+void User::validatePasswords(QString errorMessage, QString password, QString passwordConfirm) {
+    bool passwordsEqual = password == passwordConfirm;
+
+    if (!passwordsEqual) {
+        setError(errorMessage);
+        setIsValid(false);
+    }
+}
+
+void User::validateField(QString errorMessage, QString text) {
+    if (isEmpty(text)) {
+        setError(errorMessage);
+        setIsValid(false);
+    }
+}
+
+void User::validateFields() {
+    setError("");
+    setIsValid(true);
+
+    validatePasswords("User passwords don't match", userPassword, userPasswordConfirm);
+    validatePasswords("Root passwords don't match", rootPassword, rootPasswordConfirm);
+
+    validateField("User name should not be empty", userName);
+    validateField("User password should not be empty", userPassword);
+    validateField("User password should not be empty", userPasswordConfirm);
+
+    validateField("Root password should not be empty", rootPassword);
+    validateField("Root password should not be empty", rootPasswordConfirm);
+
+    validateField("Host name should not be empty", hostName);
+}

--- a/src/lib/user.cpp
+++ b/src/lib/user.cpp
@@ -97,15 +97,18 @@ void User::validateFields() {
     setError("");
     setIsValid(true);
 
-    validatePasswords("User passwords don't match", userPassword, userPasswordConfirm);
-    validatePasswords("Root passwords don't match", rootPassword, rootPasswordConfirm);
+    validatePasswords(tr("User passwords don't match"), userPassword, userPasswordConfirm);
+    validatePasswords(tr("Root passwords don't match"), rootPassword, rootPasswordConfirm);
 
-    validateField("User name should not be empty", userName);
-    validateField("User password should not be empty", userPassword);
-    validateField("User password should not be empty", userPasswordConfirm);
+    validateField(tr("User name should not be empty"), userName);
 
-    validateField("Root password should not be empty", rootPassword);
-    validateField("Root password should not be empty", rootPasswordConfirm);
+    QString emptyUserPasswordError = tr("User password should not be empty");
+    validateField(emptyUserPasswordError, userPassword);
+    validateField(emptyUserPasswordError, userPasswordConfirm);
 
-    validateField("Host name should not be empty", hostName);
+    QString emptyRootPasswordError = tr("Root password should not be empty");
+    validateField(emptyRootPasswordError, rootPassword);
+    validateField(emptyRootPasswordError, rootPasswordConfirm);
+
+    validateField(tr("Host name should not be empty"), hostName);
 }

--- a/src/lib/user.hpp
+++ b/src/lib/user.hpp
@@ -1,0 +1,58 @@
+#ifndef USER_HPP
+#define USER_HPP
+
+#include <QObject>
+
+class User : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString hostName READ getHostName WRITE setHostName)
+    Q_PROPERTY(QString userName READ getUserName WRITE setUserName)
+    Q_PROPERTY(QString userPassword READ getUserPassword WRITE setUserPassword)
+    Q_PROPERTY(QString userPasswordConfirm READ getUserPasswordConfirm WRITE setUserPasswordConfirm)
+    Q_PROPERTY(QString rootPassword READ getRootPassword WRITE setRootPassword)
+    Q_PROPERTY(QString rootPasswordConfirm READ getRootPasswordConfirm WRITE setRootPasswordConfirm)
+    Q_PROPERTY(QString error READ getError NOTIFY errorChanged)
+    Q_PROPERTY(bool isValid READ getIsValid NOTIFY validationChanged)
+
+private:
+    QString hostName;
+    QString userName;
+    QString userPassword;
+    QString userPasswordConfirm;
+    QString rootPassword;
+    QString rootPasswordConfirm;
+    QString error = "";
+    bool isValid = false;
+
+    void validatePasswords(QString errorMessage, QString password, QString passwordConfirm);
+    void validateField(QString errorMessage, QString text);
+
+public:
+    explicit User(QObject *parent = nullptr);
+
+    QString getHostName();
+    QString getUserName();
+    QString getUserPassword();
+    QString getUserPasswordConfirm();
+    QString getRootPassword();
+    QString getRootPasswordConfirm();
+    QString getError();
+    bool getIsValid();
+
+    Q_INVOKABLE void setHostName(QString hostname);
+    Q_INVOKABLE void setUserName(QString username);
+    Q_INVOKABLE void setUserPassword(QString password);
+    Q_INVOKABLE void setUserPasswordConfirm(QString passwordConfirm);
+    Q_INVOKABLE void setRootPassword(QString password);
+    Q_INVOKABLE void setRootPasswordConfirm(QString passwordConfirm);
+    Q_INVOKABLE void validateFields();
+    void setError(QString errorMessage);
+    void setIsValid(bool valid);
+
+signals:
+    void errorChanged();
+    void validationChanged();
+};
+
+#endif // USER_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@
 #include "lib/network.hpp"
 #include "lib/mirrors.hpp"
 #include "lib/locales.hpp"
+#include "lib/user.hpp"
 
 int main(int argc, char *argv[])
 {
@@ -59,6 +60,7 @@ int main(int argc, char *argv[])
     Network * m_net = new Network(&view);
     Mirrors * m_mirrors = new Mirrors(&view);
     Locales * m_locales = new Locales(&view);
+    User * m_user = new User(&view);
 
     // Context props
     context->setContextProperty(QStringLiteral("translations"), m_translations);
@@ -66,6 +68,7 @@ int main(int argc, char *argv[])
     context->setContextProperty(QStringLiteral("net"), m_net);
     context->setContextProperty(QStringLiteral("mirrors"), m_mirrors);
     context->setContextProperty(QStringLiteral("locales"), m_locales);
+    context->setContextProperty(QStringLiteral("user"), m_user);
     context->setContextProperty(QStringLiteral("assetsPath"), appPath.resolved(QStringLiteral(ASSETS_PATH)));
     
     // Some connections


### PR DESCRIPTION
## What does it do
This Pull Request adds the User setup step, which includes password and hostname settings.

## Checklist
- [x] Add field for user name
- [x] Add fields for user password and confirmation
- [x] Add fields for root password and confirmation
- [x] Add field for hostname
- [x] Add locales

## How to test
Proceed through the steps until the user setup or set the step to be the first one manually, changing:
https://github.com/PedroHLC/chaotic-installer-qt/blob/50b8c5a9541d277562f7bb16f394b20566918a43/qml/MainContainer.qml#L74
to:
```qml
initialItem: userSetup
```

Resolves #8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pedrohlc/chaotic-installer-qt/11)
<!-- Reviewable:end -->
