### PR TITLE
[Guides] Removed -project from qmake build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pacman -S qt5-base qt5-quickcontrols2 libinput libxkbcommon qmltermwidget
 ```
 pacman -S qt5-tools
 cd niemeyer
-qmake -makefile -project niemeyer.pro
+qmake -makefile niemeyer.pro
 make
 lrelease niemeyer.pro
 ```


### PR DESCRIPTION
qmake is meant to be run with -project or -makefile,
as we want to generate the makefile, and we already have .pro.
only -makefile is needed
-makefile puts qmake into makefile generation mode, interpreting files as project files ready to be processed.